### PR TITLE
Print example configuration values

### DIFF
--- a/configuration.c
+++ b/configuration.c
@@ -9,7 +9,12 @@ static unsigned char *compute_simple_hash(const char *str) {
     unsigned char *hash = malloc(20);
     if (!hash) return NULL;
     for (size_t i = 0; i < 20; ++i) {
-        hash[i] = (unsigned char)(i < len ? str[i] : i);
+        unsigned char c = 0;
+        if (i < len)
+            c = (unsigned char)str[i];
+        else
+            c = (unsigned char)i;
+        hash[i] = c;
     }
     return hash;
 }

--- a/test_configuration.c
+++ b/test_configuration.c
@@ -37,12 +37,41 @@ int main() {
 
         if (!strstr(ent->d_name, ".conf"))
             continue;
-        char path[256];
+        char path[512];
         snprintf(path, sizeof(path), "examples/%s", ent->d_name);
 
         cfg = configuration_load_from_file(path);
         assert(cfg != NULL);
         assert(configuration_get_wif(cfg) != NULL);
+
+        /* Print configuration details */
+        const char *work_str = "START";
+        switch (configuration_get_work(cfg)) {
+            case WORK_END: work_str = "END"; break;
+            case WORK_JUMP: work_str = "JUMP"; break;
+            case WORK_ROTATE: work_str = "ROTATE"; break;
+            case WORK_SEARCH: work_str = "SEARCH"; break;
+            case WORK_ALIKE: work_str = "ALIKE"; break;
+            default: break;
+        }
+
+        printf("Configuration from %s:\n", path);
+        printf("  Work: %s\n", work_str);
+        printf("  WIF: %s\n", configuration_get_wif(cfg));
+        printf("  Target Address: %s\n",
+               configuration_get_target_address(cfg)
+                   ? configuration_get_target_address(cfg)
+                   : "(none)");
+        printf("  WIF Status: %s\n",
+               configuration_get_wif_status(cfg)
+                   ? configuration_get_wif_status(cfg)
+                   : "(none)");
+        printf("  Compressed: %d\n", configuration_is_compressed(cfg));
+        printf("  is_p2sh: %d\n", cfg->is_p2sh);
+        for (guess_entry *ge = cfg->guess; ge; ge = ge->next) {
+            printf("  Guess %d: %s\n", ge->index, ge->chars);
+        }
+
         configuration_free(cfg);
         parsed++;
     }


### PR DESCRIPTION
## Summary
- print configuration contents when loading example config files
- eliminate warnings in `compute_simple_hash`
- silence `snprintf` truncation warning

## Testing
- `gcc -Wall -Wextra configuration.c test_configuration.c -o test_config && ./test_config | tail -n 5`
