### PR TITLE
Add C main program and integration test

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,25 @@ gcc -Wall configuration.c test_configuration.c -o test_config
 
 The worker module can be built in a similar way by compiling `worker.c` together
 with the configuration sources if you want to experiment with it.
+
+### Main program
+
+The repository now contains a small C `main` program translated from the
+original Java entry point.  Build it together with the other modules:
+
+```sh
+gcc -Wall configuration.c worker.c main.c -o wifcrack
+```
+
+You can then run it with one of the example configuration files:
+
+```sh
+./wifcrack examples/example_ALIKE.conf
+```
+
+An integration test is provided in `test_main.c` and can be executed with:
+
+```sh
+gcc -Wall configuration.c worker.c test_main.c -o test_main
+./test_main
+```

--- a/footer.txt
+++ b/footer.txt
@@ -1,0 +1,1 @@
+Program finished.

--- a/help.txt
+++ b/help.txt
@@ -1,0 +1,1 @@
+Usage: wifcrack <config> [email.conf]

--- a/main.c
+++ b/main.c
@@ -1,0 +1,82 @@
+#include "configuration.h"
+#include "worker.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static void show_file(const char *filename) {
+    FILE *f = fopen(filename, "r");
+    if (!f) {
+        perror(filename);
+        return;
+    }
+    char buf[256];
+    while (fgets(buf, sizeof(buf), f)) {
+        char *p = buf;
+        while (*p == ' ' || *p == '\t') p++;
+        size_t len = strlen(p);
+        while (len > 0 && (p[len-1] == '\n' || p[len-1] == '\r'))
+            p[--len] = '\0';
+        printf("%s\n", p);
+    }
+    fclose(f);
+}
+
+static void read_email_configuration(Configuration *config, const char *file) {
+    FILE *f = fopen(file, "r");
+    if (!f) {
+        fprintf(stderr, "not found: %s\n", file);
+        exit(-1);
+    }
+    char line[512];
+    int line_number = 0;
+    char *email = NULL;
+    /* For this simplified port we only care about the first line (email address) */
+    while (fgets(line, sizeof(line), f)) {
+        if (line[0] == '#' || line[0] == '\n' || line[0] == '\r')
+            continue;
+        size_t len = strlen(line);
+        while (len > 0 && (line[len-1] == '\n' || line[len-1] == '\r'))
+            line[--len] = '\0';
+        if (line_number == 0) {
+            email = strdup(line);
+            break;
+        }
+        line_number++;
+    }
+    fclose(f);
+    if (email) {
+        configuration_set_email(config, email, NULL);
+        printf("Email configured (to: '%s')\n", email);
+        free(email);
+    }
+}
+
+int main(int argc, char **argv) {
+    if (argc < 2 || (strcmp(argv[1], "--help") == 0)) {
+        show_file("help.txt");
+        show_file("footer.txt");
+        return 0;
+    }
+
+    const char *config_file = argv[1];
+    Configuration *cfg = configuration_load_from_file(config_file);
+    if (!cfg) {
+        fprintf(stderr, "Failed to load configuration: %s\n", config_file);
+        return 1;
+    }
+
+    if (argc > 2) {
+        read_email_configuration(cfg, argv[2]);
+    }
+
+    Worker *worker = worker_create(cfg);
+    worker_run(worker);
+
+    worker_free(worker);
+    configuration_free(cfg);
+
+    show_file("footer.txt");
+    return 0;
+}
+

--- a/test_main.c
+++ b/test_main.c
@@ -1,0 +1,23 @@
+#include "configuration.h"
+#include "worker.h"
+#include <assert.h>
+#include <stdio.h>
+
+int main() {
+    Configuration *cfg = configuration_load_from_file("examples/example_ALIKE.conf");
+    assert(cfg != NULL);
+
+    Worker *w = worker_create(cfg);
+    assert(w != NULL);
+
+    worker_run(w);
+
+    /* Ensure at least one result was produced */
+    assert(worker_results_count(w) > 0);
+
+    worker_free(w);
+    configuration_free(cfg);
+
+    printf("Main integration test passed.\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- port Java `Main` class to a new `main.c`
- add simple help and footer text resources
- provide integration test `test_main.c` using the ALIKE example
- document build and run instructions in README

## Testing
- `gcc -Wall configuration.c worker.c main.c -o wifcrack`
- `gcc -Wall configuration.c worker.c test_main.c -o test_main`
- `gcc -Wall configuration.c test_configuration.c -o test_config`
- `./test_config`
- `./test_main`
